### PR TITLE
Potential license issue was resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,5 +59,3 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
-
-Note: Installing this package (osmosis-aws-driver) installs the boto3 package which also has an Apache-2.0 license. Installing boto3 installs the docutils package. The docutils package might have licensing that is incompatible with the Apache-2.0 license. We have opened [an issue](https://github.com/boto/boto3/issues/1916) on the boto3 repository to let them know about the potential licensing conflict and to resolve it if necessary.


### PR DESCRIPTION
There was a potential issue with the licensing of the `docutils` package (which is installed when installing `boto3`). I opened an issue about that on the `boto3` repository, and [the response to that issue](https://github.com/boto/boto3/issues/1916#issuecomment-481018119) convinced me that it's not a problem: the GPLv3 code might be used internally by the people who work on the `docutils` package, but it doesn't get bundled with the `docutils` package.
